### PR TITLE
fix: add missing " in cmd string

### DIFF
--- a/after/ftplugin/rst/instantRst.vim
+++ b/after/ftplugin/rst/instantRst.vim
@@ -110,7 +110,7 @@ fun! s:startDaemon(file) "{{{
                     \.args_template
                     \.args_local
                     \.args_additional_dirs
-                    \.' >/dev/null'
+                    \.'" >/dev/null'
                     \.' 2>&1'
                     \.' &'
         call s:system(cmd)


### PR DESCRIPTION
fail to start instantRst due to the mismathed `"` in cmd string 

```
sh -c "instantRst -f /Users/kada/desktop/test.rst >/dev/null 2>&1
```